### PR TITLE
Color rows of the table based on completion status

### DIFF
--- a/meteor/Task.jsx
+++ b/meteor/Task.jsx
@@ -7,10 +7,21 @@ Task = React.createClass({
 		alert("Create an issue to delete a promise")
 		//Meteor.call("removeTask", this.props.task._id);
 	},
+	taskStatus(){
+		if (this.props.task.completed) {
+			return "completed";
+		}
+		else if (this.props.task.started) {
+			return "started";
+		}
+		else {
+			return "not-started";
+		}
+	},
 	
 	render(){
 		return (
-			<tr >
+			<tr className={this.taskStatus()}>
 				<td>{this.props.task.no}</td>
 				<td>
 				<span className="textPointer" onClick={this.props.showModal.bind(null, this.props.task)}>

--- a/meteor/index.css
+++ b/meteor/index.css
@@ -20,3 +20,18 @@
 	text-align: center;
 	border: 0px;
 }
+
+.started{
+	color: #FFA500;
+	/*yellow*/
+}
+
+.completed{
+	color: #00C864;
+	/*green*/
+}
+
+.not-started{
+	color: #1A1A1A;
+	/*dark grey*/
+}


### PR DESCRIPTION
Allows you to gauge completion status at a glance. Depends on `started` and `completed` json fields, same as the counter on the front page.

Since this is my first experience with react, I don't want to merge it myself. @okpatil4u or @bogas04, could you take a look and merge if it's ok?
